### PR TITLE
Make code more idiomatic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ clap = { version = "2.26.0", features = ["yaml"] }
 walkdir = "1.0.7"
 ucl = { git = "https://github.com/pizzamig/ucl-rs" }
 syslog = "3.3.0"
+url = "1.7.0"

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 repoctl would be a FreeBSD package repository management helper, written in Rust.
 
 It's my first project in rust, so instability, a lot of rewrites and code ugliness is expected
+
+## Requirements
+ 
+* autotools

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,7 @@
+extend readme
+  requirements -> autools
+mutability
+    fuf and fuf2 in tests (which are identical)
+    unwrap_or_default()
+    No default for repo
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,0 @@
-extend readme
-  requirements -> autools
-mutability
-    fuf and fuf2 in tests (which are identical)
-    unwrap_or_default()
-    No default for repo
-

--- a/src/bin/repoctl.rs
+++ b/src/bin/repoctl.rs
@@ -65,16 +65,12 @@ fn main() {
             if all {
                 println!("Available repos:");
                 for r in &repos {
-                    println!("\trepo: {}", r.name);
-                    println!("\turl: {}", r.url);
-                    println!("\tenabled: {}", r.enabled);
-                    println!();
+                    println!("{}", r);
                 }
             } else {
                 println!("Enabled repos:");
                 for r in repos.iter().filter(|x| x.enabled) {
-                    println!("\trepo: {}", r.name);
-                    println!("\turl: {}", r.url);
+                    println!("{}", r);
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,4 @@
+extern crate ucl;
+extern crate url;
+
 pub mod repository;

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -3,19 +3,19 @@ use std::io::{BufRead, BufReader};
 use std::convert::From;
 use std::path::Path;
 use std::fs::OpenOptions;
-use url::{Url, ParseError};
+use url::{ParseError, Url};
 use ucl;
 
 #[derive(PartialEq, Debug)]
-pub enum MyError {
+pub enum RepoError {
     URLError(ParseError),
     UCIError,
     NameError,
 }
 
-impl From<ParseError> for MyError {
-    fn from(e: ParseError) -> MyError {
-        MyError::URLError(e)
+impl From<ParseError> for RepoError {
+    fn from(e: ParseError) -> RepoError {
+        RepoError::URLError(e)
     }
 }
 
@@ -78,7 +78,7 @@ fn get_section_name(st: &str) -> Option<String> {
 }
 
 /// it parses one repository description
-pub fn parse_string(entry: String) -> Result<Repo, MyError> {
+pub fn parse_string(entry: String) -> Result<Repo, RepoError> {
     let trimmed = entry
         .lines()
         .map(line_trim)
@@ -87,8 +87,7 @@ pub fn parse_string(entry: String) -> Result<Repo, MyError> {
     if let Some(name) = get_section_name(trimmed.as_ref()) {
         r.name = name;
     } else {
-        return Err(MyError::NameError);
-        return Err(MyError::NameError);
+        return Err(RepoError::NameError);
     }
     let parsy = ucl::Parser::new();
     if let Ok(config) = parsy.parse(trimmed) {
@@ -105,7 +104,7 @@ pub fn parse_string(entry: String) -> Result<Repo, MyError> {
         }
         Ok(r)
     } else {
-        Err(MyError::UCIError)
+        Err(RepoError::UCIError)
     }
 }
 
@@ -213,7 +212,7 @@ mod tests {
             url: Some(Url::parse("http://pkg.bsd").unwrap()),
             enabled: false,
         };
-        assert_eq!(Err(MyError::NameError), parse_string("".to_string()));
+        assert_eq!(Err(RepoError::NameError), parse_string("".to_string()));
         assert_eq!(Ok(ff), parse_string("FreeBSD:{}".to_string()));
         assert_eq!(Ok(ft), parse_string("FreeBSD:{enabled:yes}".to_string()));
         assert_eq!(


### PR DESCRIPTION
This changes the type of the url field from `String` to `Option<url::Url>` and adds error handling to repo parsing.